### PR TITLE
Update Gemini API client configuration

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -1,0 +1,2 @@
+# Copy this file to `.env.local` and replace the placeholder with your Gemini API key.
+VITE_GEMINI_API_KEY=your_gemini_api_key_here

--- a/README.md
+++ b/README.md
@@ -15,6 +15,6 @@ View your app in AI Studio: https://ai.studio/apps/drive/1l44N6gc2J0zM6jcP1IiNoB
 
 1. Install dependencies:
    `npm install`
-2. Set the `GEMINI_API_KEY` in [.env.local](.env.local) to your Gemini API key
+2. Set the `VITE_GEMINI_API_KEY` in your `.env.local` file to your Gemini API key
 3. Run the app:
    `npm run dev`

--- a/README.md
+++ b/README.md
@@ -16,6 +16,5 @@ View your app in AI Studio: https://ai.studio/apps/drive/1l44N6gc2J0zM6jcP1IiNoB
 1. Install dependencies:
    `npm install`
 2. Copy `.env.local.example` to `.env.local` and replace the placeholder with your Gemini API key (prefixed with `VITE_`).
-   - Alternatifnya, Anda bisa menjalankan aplikasi tanpa berkas `.env.local` lalu memasukkan kunci melalui formulir "Konfigurasi Gemini API Key" yang muncul di tampilan agen. Nilainya akan tersimpan hanya di browser yang sedang digunakan.
 3. Run the app:
    `npm run dev`

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ View your app in AI Studio: https://ai.studio/apps/drive/1l44N6gc2J0zM6jcP1IiNoB
 
 1. Install dependencies:
    `npm install`
-2. Copy `.env.local.example` to `.env.local` and replace the placeholder with your Gemini API key (prefixed with `VITE_`)
+2. Copy `.env.local.example` to `.env.local` and replace the placeholder with your Gemini API key (prefixed with `VITE_`).
+   - Alternatifnya, Anda bisa menjalankan aplikasi tanpa berkas `.env.local` lalu memasukkan kunci melalui formulir "Konfigurasi Gemini API Key" yang muncul di tampilan agen. Nilainya akan tersimpan hanya di browser yang sedang digunakan.
 3. Run the app:
    `npm run dev`

--- a/README.md
+++ b/README.md
@@ -15,6 +15,6 @@ View your app in AI Studio: https://ai.studio/apps/drive/1l44N6gc2J0zM6jcP1IiNoB
 
 1. Install dependencies:
    `npm install`
-2. Set the `VITE_GEMINI_API_KEY` in your `.env.local` file to your Gemini API key
+2. Copy `.env.local.example` to `.env.local` and replace the placeholder with your Gemini API key (prefixed with `VITE_`)
 3. Run the app:
    `npm run dev`

--- a/index.html
+++ b/index.html
@@ -29,22 +29,9 @@
       animation: bean-pulse 2s cubic-bezier(0.4, 0, 0.6, 1) infinite, fade-in-down 0.5s ease-out forwards;
     }
   </style>
-<script type="importmap">
-{
-  "imports": {
-    "react": "https://aistudiocdn.com/react@^19.2.0",
-    "react-dom/": "https://aistudiocdn.com/react-dom@^19.2.0/",
-    "react/": "https://aistudiocdn.com/react@^19.2.0/",
-    "@google/genai": "https://aistudiocdn.com/@google/genai@^1.22.0"
-  }
-}
-</script>
-<!-- Add Babel Standalone for in-browser transpilation of TSX/JSX -->
-<script src="https://unpkg.com/@babel/standalone/babel.min.js"></script>
 </head>
 <body class="bg-slate-100">
   <div id="root"></div>
-  <!-- Use text/babel to let Babel transpile the script -->
-  <script type="text/babel" data-type="module" src="/index.tsx"></script>
+  <script type="module" src="/index.tsx"></script>
 </body>
 </html>

--- a/services/geminiService.ts
+++ b/services/geminiService.ts
@@ -1,37 +1,147 @@
 import { GoogleGenAI, Content, GenerateContentResponse } from "@google/genai";
 import type { ChatMessage } from '../types';
 
-let ai: GoogleGenAI;
+const LOCAL_STORAGE_KEYS = ['app.geminiApiKey', 'VITE_GEMINI_API_KEY', 'GEMINI_API_KEY', 'API_KEY'];
+
+type ApiKeySource = 'vite' | 'runtime' | 'window' | 'localStorage' | 'none';
+
+export interface GeminiApiKeyResolution {
+    key?: string;
+    source: ApiKeySource;
+}
+
+let ai: GoogleGenAI | undefined;
+let activeApiKey: string | undefined;
+
+const safeAccessRuntimeEnv = (): NodeJS.ProcessEnv | undefined => {
+    try {
+        return typeof process !== 'undefined' ? process.env : undefined;
+    } catch {
+        return undefined;
+    }
+};
+
+const readFromWindowConfig = (): string | undefined => {
+    if (typeof globalThis === 'undefined') {
+        return undefined;
+    }
+
+    const candidateKeys: Array<keyof typeof globalThis> = ['__GEMINI_API_KEY__', 'GEMINI_API_KEY', 'VITE_GEMINI_API_KEY', 'API_KEY'];
+    for (const candidate of candidateKeys) {
+        const value = (globalThis as Record<string, unknown>)[candidate];
+        if (typeof value === 'string' && value.trim()) {
+            return value.trim();
+        }
+    }
+
+    const maybeConfig = (globalThis as Record<string, unknown>).__APP_CONFIG__;
+    if (maybeConfig && typeof maybeConfig === 'object' && 'geminiApiKey' in maybeConfig) {
+        const apiKey = (maybeConfig as Record<string, unknown>).geminiApiKey;
+        if (typeof apiKey === 'string' && apiKey.trim()) {
+            return apiKey.trim();
+        }
+    }
+
+    return undefined;
+};
+
+const readFromLocalStorage = (): string | undefined => {
+    if (typeof globalThis === 'undefined' || !(globalThis as Record<string, unknown>).localStorage) {
+        return undefined;
+    }
+
+    try {
+        const storage = (globalThis as unknown as { localStorage: Storage }).localStorage;
+        for (const key of LOCAL_STORAGE_KEYS) {
+            const storedValue = storage.getItem(key);
+            if (storedValue && storedValue.trim()) {
+                return storedValue.trim();
+            }
+        }
+    } catch {
+        // Access to localStorage might be blocked (e.g., privacy mode). Swallow the error and fall back to other strategies.
+    }
+
+    return undefined;
+};
+
+export const resolveGeminiApiKey = (): GeminiApiKeyResolution => {
+    const viteApiKey = import.meta.env?.VITE_GEMINI_API_KEY?.trim();
+    if (viteApiKey) {
+        return { key: viteApiKey, source: 'vite' };
+    }
+
+    const runtimeEnv = safeAccessRuntimeEnv();
+    const runtimeApiKey = runtimeEnv?.VITE_GEMINI_API_KEY?.trim()
+        ?? runtimeEnv?.GEMINI_API_KEY?.trim()
+        ?? runtimeEnv?.API_KEY?.trim();
+    if (runtimeApiKey) {
+        return { key: runtimeApiKey, source: 'runtime' };
+    }
+
+    const windowApiKey = readFromWindowConfig();
+    if (windowApiKey) {
+        return { key: windowApiKey, source: 'window' };
+    }
+
+    const localStorageKey = readFromLocalStorage();
+    if (localStorageKey) {
+        return { key: localStorageKey, source: 'localStorage' };
+    }
+
+    return { key: undefined, source: 'none' };
+};
+
+export const storeGeminiApiKey = (apiKey: string): void => {
+    if (!apiKey.trim()) {
+        return;
+    }
+
+    if (typeof globalThis === 'undefined' || !(globalThis as Record<string, unknown>).localStorage) {
+        return;
+    }
+
+    try {
+        const storage = (globalThis as unknown as { localStorage: Storage }).localStorage;
+        for (const key of LOCAL_STORAGE_KEYS) {
+            storage.setItem(key, apiKey.trim());
+        }
+    } catch {
+        // Ignore write failures (e.g., storage disabled).
+    }
+};
+
+export const clearStoredGeminiApiKey = (): void => {
+    if (typeof globalThis === 'undefined' || !(globalThis as Record<string, unknown>).localStorage) {
+        return;
+    }
+
+    try {
+        const storage = (globalThis as unknown as { localStorage: Storage }).localStorage;
+        for (const key of LOCAL_STORAGE_KEYS) {
+            storage.removeItem(key);
+        }
+    } catch {
+        // Ignore failures.
+    }
+};
+
+export const resetGeminiClient = (): void => {
+    ai = undefined;
+    activeApiKey = undefined;
+};
 
 function getClient(): GoogleGenAI {
-    if (!ai) {
-        // Prefer Vite's client-side environment variable. Keep a fallback for the
-        // legacy GEMINI_API_KEY (used before the Vite rename) so existing
-        // deployments keep working without having to rotate secrets immediately.
-        const viteApiKey = import.meta.env?.VITE_GEMINI_API_KEY;
-
-        // When the build runs through Vite, the `process.env` lookups below are
-        // statically replaced with the configured values. Wrapping the access in
-        // a try/catch keeps things safe in the browser where `process` is not
-        // defined, while still allowing SSR/runtime environments to populate the
-        // value at execution time.
-        let runtimeEnv: NodeJS.ProcessEnv | undefined;
-        try {
-            runtimeEnv = typeof process !== 'undefined' ? process.env : undefined;
-        } catch {
-            runtimeEnv = undefined;
-        }
-
-        const apiKey = viteApiKey
-            ?? runtimeEnv?.VITE_GEMINI_API_KEY
-            ?? runtimeEnv?.GEMINI_API_KEY
-            ?? runtimeEnv?.API_KEY;
-
-        if (!apiKey) {
-            throw new Error("The VITE_GEMINI_API_KEY (or GEMINI_API_KEY for SSR) environment variable is not set. Define it in your .env.local (or deployment environment) to enable the AI features.");
-        }
-        ai = new GoogleGenAI({ apiKey });
+    const { key: apiKey } = resolveGeminiApiKey();
+    if (!apiKey) {
+        throw new Error("The VITE_GEMINI_API_KEY (or GEMINI_API_KEY for SSR) environment variable is not set. Define it in your .env.local (or deployment environment) to enable the AI features.");
     }
+
+    if (!ai || activeApiKey !== apiKey) {
+        ai = new GoogleGenAI({ apiKey });
+        activeApiKey = apiKey;
+    }
+
     return ai;
 }
 

--- a/services/geminiService.ts
+++ b/services/geminiService.ts
@@ -5,11 +5,12 @@ let ai: GoogleGenAI;
 
 function getClient(): GoogleGenAI {
     if (!ai) {
-        // Safely access process.env, which may not be defined in browser environments.
-        const apiKey = (typeof process !== 'undefined' && process.env) ? process.env.API_KEY : undefined;
+        // Prefer Vite's client-side environment variable, with SSR fallback support.
+        const apiKey = import.meta.env?.VITE_GEMINI_API_KEY
+            ?? ((typeof process !== 'undefined' && process.env) ? process.env.GEMINI_API_KEY : undefined);
 
         if (!apiKey) {
-            throw new Error("The API_KEY environment variable is not set. Please configure it in your deployment environment to use the AI features.");
+            throw new Error("The VITE_GEMINI_API_KEY (or GEMINI_API_KEY for SSR) environment variable is not set. Please configure it in your deployment environment to use the AI features.");
         }
         ai = new GoogleGenAI({ apiKey });
     }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,7 +11,8 @@
     ],
     "skipLibCheck": true,
     "types": [
-      "node"
+      "node",
+      "vite/client"
     ],
     "moduleResolution": "bundler",
     "isolatedModules": true,

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -4,6 +4,7 @@ import react from '@vitejs/plugin-react';
 
 export default defineConfig(({ mode }) => {
     const env = loadEnv(mode, '.', '');
+    const resolvedGeminiKey = env.VITE_GEMINI_API_KEY ?? env.GEMINI_API_KEY ?? env.API_KEY;
     return {
       server: {
         port: 3000,
@@ -11,8 +12,9 @@ export default defineConfig(({ mode }) => {
       },
       plugins: [react()],
       define: {
-        'process.env.API_KEY': JSON.stringify(env.GEMINI_API_KEY),
-        'process.env.GEMINI_API_KEY': JSON.stringify(env.GEMINI_API_KEY)
+        'process.env.API_KEY': JSON.stringify(resolvedGeminiKey),
+        'process.env.GEMINI_API_KEY': JSON.stringify(resolvedGeminiKey),
+        'process.env.VITE_GEMINI_API_KEY': JSON.stringify(resolvedGeminiKey)
       },
       resolve: {
         alias: {


### PR DESCRIPTION
## Summary
- read the Gemini client API key from `import.meta.env.VITE_GEMINI_API_KEY` with an SSR fallback
- improve the missing-key error message and document the new environment variable
- include Vite client types so the new env reference type-checks cleanly

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e12c5bec14832d93126549e434487e